### PR TITLE
Rename project as QXGraphs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,8 @@ jobs:
       - run: |
           julia --project=docs -e '
             using Documenter: doctest
-            using QXGraph
-            doctest(QXGraph)'
+            using QXGraphs
+            doctest(QXGraphs)'
       - run: julia --project=docs docs/make.jl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         version:
           - '1.5'
+          - '1.6'
         os:
           - ubuntu-latest
         arch:

--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-name = "QXGraph"
+name = "QXGraphs"
 uuid = "b15f1ded-d19a-4aca-a940-1991fcfc7750"
 authors = ["QuantEx team"]
 version = "0.1.2"
@@ -7,7 +7,7 @@ version = "0.1.2"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 
 [compat]
-julia = "1.5"
+julia = "1.5, 1.6"
 LightGraphs = "1.3"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # QXGraphs
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaQX.github.io/QXGraph.jl/stable)
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaQX.github.io/QXGraph.jl/dev)
-[![Build Status](https://github.com/JuliaQX/QXGraph.jl/workflows/CI/badge.svg)](https://github.com/JuliaQX/QXGraph.jl/actions)
-[![Build Status](https://github.com/JuliaQX/QXGraph.jl/badges/master/pipeline.svg)](https://github.com/JuliaQX/QXGraph.jl/pipelines)
-[![Coverage](https://github.com/JuliaQX/QXGraph.jl/badges/master/coverage.svg)](https://github.com/JuliaQX/QXGraph.jl/commits/master)
-[![Coverage](https://codecov.io/gh/JuliaQX/QXGraph.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaQX/QXGraph.jl)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaQX.github.io/QXGraphs.jl/stable)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaQX.github.io/QXGraphs.jl/dev)
+[![Build Status](https://github.com/JuliaQX/QXGraphs.jl/workflows/CI/badge.svg)](https://github.com/JuliaQX/QXGraphs.jl/actions)
+<!-- [![Build Status](https://github.com/JuliaQX/QXGraphs.jl/badges/master/pipeline.svg)](https://github.com/JuliaQX/QXGraphs.jl/pipelines)
+[![Coverage](https://github.com/JuliaQX/QXGraphs.jl/badges/master/coverage.svg)](https://github.com/JuliaQX/QXGraphs.jl/commits/master) -->
+[![Coverage](https://codecov.io/gh/JuliaQX/QXGraphs.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaQX/QXGraphs.jl)
 
 
 QXGraphs is a Julia package for analysing and manipulating graph structures describing tensor 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# QXGraph
+# QXGraphs
 
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaQX.github.io/QXGraph.jl/stable)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaQX.github.io/QXGraph.jl/dev)
@@ -8,21 +8,21 @@
 [![Coverage](https://codecov.io/gh/JuliaQX/QXGraph.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaQX/QXGraph.jl)
 
 
-QXGraph is a Julia package for analysing and manipulating graph structures describing tensor 
+QXGraphs is a Julia package for analysing and manipulating graph structures describing tensor 
 networks in the QuantEx project. It provides functions for solving graph theoretic problems 
 related to the task of efficiently slicing and contracting a tensor network.
 
-QXGraph was developed as part of the QuantEx project, one of the individual software 
+QXGraphs was developed as part of the QuantEx project, one of the individual software 
 projects of WP8 of [PRACE](https://prace-ri.eu/) 6IP.
 
 # Installation
 
-QXGraph is a Julia package and can be installed using Julia's inbuilt package manager from 
+QXGraphs is a Julia package and can be installed using Julia's inbuilt package manager from 
 the Julia REPL using.
 
 ```
 import Pkg
-Pkg.add("QXGraph")
+Pkg.add("QXGraphs")
 ```
 
 To ensure everything is working, the unittests can be run using
@@ -33,11 +33,11 @@ import Pkg; Pkg.test()
 
 ## Example usage
 
-An example of how QXGraph can be used to calculate a vertex elimination order for a graph
+An example of how QXGraphs can be used to calculate a vertex elimination order for a graph
 looks like:
 
 ```
-using QXGraph
+using QXGraphs
 
 # Create a LabeledGraph with N fully connected vertices.
 N = 10

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,15 +1,15 @@
-using QXGraph
+using QXGraphs
 using Documenter
 
-DocMeta.setdocmeta!(QXGraph, :DocTestSetup, :(using QXGraph); recursive=true)
+DocMeta.setdocmeta!(QXGraphs, :DocTestSetup, :(using QXGraphs); recursive=true)
 makedocs(;
-    modules=[QXGraph],
+    modules=[QXGraphs],
     authors="QuantEx team",
-    repo="https://github.com/JuliaQX/QXGraph.jl/blob/{commit}{path}#L{line}",
-    sitename="QXGraph.jl",
+    repo="https://github.com/JuliaQX/QXGraphs.jl/blob/{commit}{path}#L{line}",
+    sitename="QXGraphs.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",
-        canonical="https://JuliaQX.github.io/QXGraph.jl",
+        canonical="https://JuliaQX.github.io/QXGraphs.jl",
         assets=String[],
     ),
     pages=[
@@ -22,5 +22,5 @@ makedocs(;
 )
 
 deploydocs(;
-    repo="github.com/JuliaQX/QXGraph.jl",
+    repo="github.com/JuliaQX/QXGraphs.jl",
 )

--- a/docs/src/LabeledGraph.md
+++ b/docs/src/LabeledGraph.md
@@ -1,12 +1,12 @@
 # Labeled Graphs
 
-QXGraph uses the `SimpleGraph` struct from the LightGraphs package to store graph structures. 
-However, some of the algorithms implemented in QXGraph repeatedly modify the graph they work 
+QXGraphs uses the `SimpleGraph` struct from the LightGraphs package to store graph structures. 
+However, some of the algorithms implemented in QXGraphs repeatedly modify the graph they work 
 on, either by removing or adding vertices in varying orders, and in turn alter the manner in 
 which vertices in the graph are indexed. This can make it difficult to track where vertices
 end up in a graph after many modifications are made, which needs to be done if the vertices
 are used to index different variables in an alternate data structure, such as indices or 
-tensors in a tensor network. To this end, QXGraph defines a LabeledGraph struct which pairs
+tensors in a tensor network. To this end, QXGraphs defines a LabeledGraph struct which pairs
 a `SimpleGraph` with and array of julia symbols which can be used to identify vertices in
 a graph after modifications have been made. 
 
@@ -24,7 +24,7 @@ graph are now indexed in the new graph by looking at how the corresponding label
 indexed inside the LabeledGraph.
 
 ```
-using QXGraph
+using QXGraphs
 
 # Create a LabeledGraph with N vertices
 N = 10

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,14 +1,14 @@
 ```@meta
-CurrentModule = QXGraph
+CurrentModule = QXGraphs
 ```
 
-# QXGraph
+# QXGraphs
 
-QXGraph is a Julia package for analysing and manipulating graph structures describing tensor 
+QXGraphs is a Julia package for analysing and manipulating graph structures describing tensor 
 networks in the QuantEx project. It provides functions for solving graph theoretic problems 
 related to the task of efficiently slicing and contracting a tensor network.
 
-QXGraph was developed as part of the QuantEx project, one of the individual software 
+QXGraphs was developed as part of the QuantEx project, one of the individual software 
 projects of WP8 of [PRACE](https://prace-ri.eu/) 6IP.
 
 
@@ -16,12 +16,12 @@ projects of WP8 of [PRACE](https://prace-ri.eu/) 6IP.
 
 ### Installation
 
-QXGraph is a Julia package and can be installed using Julia's inbuilt package manager from 
+QXGraphs is a Julia package and can be installed using Julia's inbuilt package manager from 
 the Julia REPL using.
 
 ```
 import Pkg
-Pkg.add("QXGraph")
+Pkg.add("QXGraphs")
 ```
 
 To ensure everything is working, the unittests can be run using
@@ -32,11 +32,11 @@ import Pkg; Pkg.test()
 
 ### Example usage
 
-An example of how QXGraph can be used to calculate a vertex elimination order for a graph
+An example of how QXGraphs can be used to calculate a vertex elimination order for a graph
 looks like:
 
 ```
-using QXGraph
+using QXGraphs
 
 # Create a LabeledGraph with N fully connected vertices.
 N = 10
@@ -53,10 +53,10 @@ elimination_order, md = quickbb(G)
 @show md[:treewidth]
 ```
 
-For more information about the algorithms made available by QXGraph please consult the contents below.
+For more information about the algorithms made available by QXGraphs please consult the contents below.
 
 
 ### Contents
 
   - [Treewidth Algorithms](@ref) Describes useful algorithms for analysing a tensor network's line graph.
-  - [Labeled Graphs](@ref) Describes the QXGraph `LabeledGraph` struct for representing graphs.
+  - [Labeled Graphs](@ref) Describes the QXGraphs `LabeledGraph` struct for representing graphs.

--- a/docs/src/treewidth.md
+++ b/docs/src/treewidth.md
@@ -7,7 +7,7 @@ it is eliminated according the order. In the context of tensor network contracti
 treewidth serves as an indirect measure of the size of the largest intermediate tensor 
 produced while contracting a network according to a the contraction plan built from the
 elimination order. It is thus also an indirect measure of the computational cost of 
-contracting a tensor network according to the corresponding contraction plan. QXGraph 
+contracting a tensor network according to the corresponding contraction plan. QXGraphs 
 provides functions for finding such elimination orders with minimal treewidth.
 
 ## Vertex Elimination Orders
@@ -16,7 +16,7 @@ A standard algorithm for finding elimination orders, whose treewidth provides a 
 bound for the minimal treewidth of a graph, is known as the QuickBB algorithm.
 It was first proposed by Vibhav Gogate and Rina Dechter in their 2004 paper "A complete 
 Anytime Algorithm for Treewidth". The paper along with a binary implementation of the 
-algorithm is provided [here](http://www.hlt.utdallas.edu/~vgogate/quickbb.html). QXGraph
+algorithm is provided [here](http://www.hlt.utdallas.edu/~vgogate/quickbb.html). QXGraphs
 provides a julia wrapper for their binary which requires a linux OS.
 
 ```@docs

--- a/src/QXGraphs.jl
+++ b/src/QXGraphs.jl
@@ -1,4 +1,4 @@
-module QXGraph
+module QXGraphs
 
 include("LabeledGraph.jl")
 include("treewidth.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using QXGraph
+using QXGraphs
 using Test
 
 import LightGraphs; lg = LightGraphs


### PR DESCRIPTION
### Summary

The name QXGraph was updated to QXGraphs in all files and the Project.toml file was updated to include Julia 1.6 as a compatible version.

### Rationale

The name needed to be updated in order to automatically register the package as a Julia package.

#### Implementation Details

#### Additional notes

<hr>

***Check before merging:***

- [x] All discussions are resolved
- [x] New code is covered by appropriate tests
- [x] Tests are passing locally and on CI
- [x] The documentation is consistent with changes
- [x] Any code that was copied from other sources has the paper/url in a comment and is compatible with the MIT licence
- [x] Notebooks/examples not covered by unittests have been tested and updated as required
- [x] The feature branch is up-to-date with the master branch (rebase if behind)
- [ ] Incremented the version string in Project.toml file
