### PR TITLE
Rename as QXGraphDecompositions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,8 @@ jobs:
       - run: |
           julia --project=docs -e '
             using Documenter: doctest
-            using QXGraphs
-            doctest(QXGraphs)'
+            using QXGraphDecompositions
+            doctest(QXGraphDecompositions)'
       - run: julia --project=docs docs/make.jl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QXGraphDecompositions"
 uuid = "b15f1ded-d19a-4aca-a940-1991fcfc7750"
 authors = ["QuantEx team"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"

--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-name = "QXGraphs"
+name = "QXGraphDecompositions"
 uuid = "b15f1ded-d19a-4aca-a940-1991fcfc7750"
 authors = ["QuantEx team"]
 version = "0.1.2"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# QXGraphs
+# QXGraphDecompositions
 
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaQX.github.io/QXGraphs.jl/stable)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaQX.github.io/QXGraphs.jl/dev)
@@ -8,21 +8,21 @@
 [![Coverage](https://codecov.io/gh/JuliaQX/QXGraphs.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaQX/QXGraphs.jl)
 
 
-QXGraphs is a Julia package for analysing and manipulating graph structures describing tensor 
+QXGraphDecompositions is a Julia package for analysing and manipulating graph structures describing tensor 
 networks in the QuantEx project. It provides functions for solving graph theoretic problems 
 related to the task of efficiently slicing and contracting a tensor network.
 
-QXGraphs was developed as part of the QuantEx project, one of the individual software 
+QXGraphDecompositions was developed as part of the QuantEx project, one of the individual software 
 projects of WP8 of [PRACE](https://prace-ri.eu/) 6IP.
 
 # Installation
 
-QXGraphs is a Julia package and can be installed using Julia's inbuilt package manager from 
+QXGraphDecompositions is a Julia package and can be installed using Julia's inbuilt package manager from 
 the Julia REPL using.
 
 ```
 import Pkg
-Pkg.add("QXGraphs")
+Pkg.add("QXGraphDecompositions")
 ```
 
 To ensure everything is working, the unittests can be run using
@@ -33,11 +33,11 @@ import Pkg; Pkg.test()
 
 ## Example usage
 
-An example of how QXGraphs can be used to calculate a vertex elimination order for a graph
+An example of how QXGraphDecompositions can be used to calculate a vertex elimination order for a graph
 looks like:
 
 ```
-using QXGraphs
+using QXGraphDecompositions
 
 # Create a LabeledGraph with N fully connected vertices.
 N = 10

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # QXGraphDecompositions
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaQX.github.io/QXGraphs.jl/stable)
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaQX.github.io/QXGraphs.jl/dev)
-[![Build Status](https://github.com/JuliaQX/QXGraphs.jl/workflows/CI/badge.svg)](https://github.com/JuliaQX/QXGraphs.jl/actions)
-<!-- [![Build Status](https://github.com/JuliaQX/QXGraphs.jl/badges/master/pipeline.svg)](https://github.com/JuliaQX/QXGraphs.jl/pipelines)
-[![Coverage](https://github.com/JuliaQX/QXGraphs.jl/badges/master/coverage.svg)](https://github.com/JuliaQX/QXGraphs.jl/commits/master) -->
-[![Coverage](https://codecov.io/gh/JuliaQX/QXGraphs.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaQX/QXGraphs.jl)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaQX.github.io/QXGraphDecompositions.jl/stable)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaQX.github.io/QXGraphDecompositions.jl/dev)
+[![Build Status](https://github.com/JuliaQX/QXGraphDecompositions.jl/workflows/CI/badge.svg)](https://github.com/JuliaQX/QXGraphDecompositions.jl/actions)
+<!-- [![Build Status](https://github.com/JuliaQX/QXGraphDecompositions.jl/badges/master/pipeline.svg)](https://github.com/JuliaQX/QXGraphDecompositions.jl/pipelines)
+[![Coverage](https://github.com/JuliaQX/QXGraphDecompositions.jl/badges/master/coverage.svg)](https://github.com/JuliaQX/QXGraphDecompositions.jl/commits/master) -->
+[![Coverage](https://codecov.io/gh/JuliaQX/QXGraphDecompositions.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaQX/QXGraphDecompositions.jl)
 
 
 QXGraphDecompositions is a Julia package for analysing and manipulating graph structures describing tensor 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,11 +5,11 @@ DocMeta.setdocmeta!(QXGraphs, :DocTestSetup, :(using QXGraphs); recursive=true)
 makedocs(;
     modules=[QXGraphs],
     authors="QuantEx team",
-    repo="https://github.com/JuliaQX/QXGraphs.jl/blob/{commit}{path}#L{line}",
+    repo="https://github.com/JuliaQX/QXGraphDecompositions.jl/blob/{commit}{path}#L{line}",
     sitename="QXGraphs.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",
-        canonical="https://JuliaQX.github.io/QXGraphs.jl",
+        canonical="https://JuliaQX.github.io/QXGraphDecompositions.jl",
         assets=String[],
     ),
     pages=[
@@ -22,5 +22,5 @@ makedocs(;
 )
 
 deploydocs(;
-    repo="github.com/JuliaQX/QXGraphs.jl",
+    repo="github.com/JuliaQX/QXGraphDecompositions.jl",
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,12 +1,12 @@
-using QXGraphs
+using QXGraphDecompositions
 using Documenter
 
-DocMeta.setdocmeta!(QXGraphs, :DocTestSetup, :(using QXGraphs); recursive=true)
+DocMeta.setdocmeta!(QXGraphDecompositions, :DocTestSetup, :(using QXGraphDecompositions); recursive=true)
 makedocs(;
-    modules=[QXGraphs],
+    modules=[QXGraphDecompositions],
     authors="QuantEx team",
     repo="https://github.com/JuliaQX/QXGraphDecompositions.jl/blob/{commit}{path}#L{line}",
-    sitename="QXGraphs.jl",
+    sitename="QXGraphDecompositions.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",
         canonical="https://JuliaQX.github.io/QXGraphDecompositions.jl",

--- a/docs/src/LabeledGraph.md
+++ b/docs/src/LabeledGraph.md
@@ -1,14 +1,15 @@
 # Labeled Graphs
 
-QXGraphs uses the `SimpleGraph` struct from the LightGraphs package to store graph structures. 
-However, some of the algorithms implemented in QXGraphs repeatedly modify the graph they work 
-on, either by removing or adding vertices in varying orders, and in turn alter the manner in 
-which vertices in the graph are indexed. This can make it difficult to track where vertices
-end up in a graph after many modifications are made, which needs to be done if the vertices
-are used to index different variables in an alternate data structure, such as indices or 
-tensors in a tensor network. To this end, QXGraphs defines a LabeledGraph struct which pairs
-a `SimpleGraph` with and array of julia symbols which can be used to identify vertices in
-a graph after modifications have been made. 
+QXGraphDecompositions uses the `SimpleGraph` struct from the LightGraphs package to store 
+graph structures. However, some of the algorithms implemented in QXGraphDecompositions 
+repeatedly modify the graph they work on, either by removing or adding vertices in varying 
+orders, and in turn alter the manner in which vertices in the graph are indexed. This can 
+make it difficult to track where vertices end up in a graph after many modifications are 
+made, which needs to be done if the vertices are used to index different variables in an 
+alternate data structure, such as indices or tensors in a tensor network. To this end, 
+QXGraphDecompositions defines a LabeledGraph struct which pairs a `SimpleGraph` with and 
+array of julia symbols which can be used to identify vertices in a graph after modifications 
+have been made. 
 
 ```@docs
 LabeledGraph
@@ -24,7 +25,7 @@ graph are now indexed in the new graph by looking at how the corresponding label
 indexed inside the LabeledGraph.
 
 ```
-using QXGraphs
+using QXGraphDecompositions
 
 # Create a LabeledGraph with N vertices
 N = 10

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,27 +1,28 @@
 ```@meta
-CurrentModule = QXGraphs
+CurrentModule = QXGraphDecompositions
 ```
 
-# QXGraphs
+# QXGraphDecompositions
 
-QXGraphs is a Julia package for analysing and manipulating graph structures describing tensor 
-networks in the QuantEx project. It provides functions for solving graph theoretic problems 
-related to the task of efficiently slicing and contracting a tensor network.
+QXGraphDecompositions is a Julia package for analysing and manipulating graph structures 
+describing tensor networks in the QuantEx project. It provides functions for solving graph 
+theoretic problems related to the task of efficiently slicing and contracting a tensor 
+network.
 
-QXGraphs was developed as part of the QuantEx project, one of the individual software 
-projects of WP8 of [PRACE](https://prace-ri.eu/) 6IP.
+QXGraphDecompositions was developed as part of the QuantEx project, one of the individual 
+software projects of WP8 of [PRACE](https://prace-ri.eu/) 6IP.
 
 
 ## Getting started
 
 ### Installation
 
-QXGraphs is a Julia package and can be installed using Julia's inbuilt package manager from 
-the Julia REPL using.
+QXGraphDecompositions is a Julia package and can be installed using Julia's inbuilt package 
+manager from the Julia REPL using.
 
 ```
 import Pkg
-Pkg.add("QXGraphs")
+Pkg.add("QXGraphDecompositions")
 ```
 
 To ensure everything is working, the unittests can be run using
@@ -32,11 +33,11 @@ import Pkg; Pkg.test()
 
 ### Example usage
 
-An example of how QXGraphs can be used to calculate a vertex elimination order for a graph
-looks like:
+An example of how QXGraphDecompositions can be used to calculate a vertex elimination order 
+for a graph looks like:
 
 ```
-using QXGraphs
+using QXGraphDecompositions
 
 # Create a LabeledGraph with N fully connected vertices.
 N = 10
@@ -46,17 +47,19 @@ for i = 1:N, j = i+1:N
 end
 
 # To get an elimination order for G with minimal treewidth we call quickbb.
-elimination_order, md = quickbb(G)
+# elimination_order, md = quickbb(G)
 @show elimination_order
 
-# The treewidth of the elimination order is contained in the metadata dictionary returned by quickbb.
+# The treewidth of the elimination order is contained in the metadata dictionary returned by 
+# quickbb.
 @show md[:treewidth]
 ```
 
-For more information about the algorithms made available by QXGraphs please consult the contents below.
+For more information about the algorithms made available by QXGraphDecompositions please 
+consult the contents below.
 
 
 ### Contents
 
   - [Treewidth Algorithms](@ref) Describes useful algorithms for analysing a tensor network's line graph.
-  - [Labeled Graphs](@ref) Describes the QXGraphs `LabeledGraph` struct for representing graphs.
+  - [Labeled Graphs](@ref) Describes the QXGraphDecompositions `LabeledGraph` struct for representing graphs.

--- a/docs/src/treewidth.md
+++ b/docs/src/treewidth.md
@@ -7,8 +7,9 @@ it is eliminated according the order. In the context of tensor network contracti
 treewidth serves as an indirect measure of the size of the largest intermediate tensor 
 produced while contracting a network according to a the contraction plan built from the
 elimination order. It is thus also an indirect measure of the computational cost of 
-contracting a tensor network according to the corresponding contraction plan. QXGraphs 
-provides functions for finding such elimination orders with minimal treewidth.
+contracting a tensor network according to the corresponding contraction plan. 
+QXGraphDecompositions provides functions for finding such elimination orders with minimal 
+treewidth.
 
 ## Vertex Elimination Orders
 
@@ -16,8 +17,8 @@ A standard algorithm for finding elimination orders, whose treewidth provides a 
 bound for the minimal treewidth of a graph, is known as the QuickBB algorithm.
 It was first proposed by Vibhav Gogate and Rina Dechter in their 2004 paper "A complete 
 Anytime Algorithm for Treewidth". The paper along with a binary implementation of the 
-algorithm is provided [here](http://www.hlt.utdallas.edu/~vgogate/quickbb.html). QXGraphs
-provides a julia wrapper for their binary which requires a linux OS.
+algorithm is provided [here](http://www.hlt.utdallas.edu/~vgogate/quickbb.html). 
+QXGraphDecompositions provides a julia wrapper for their binary which requires a linux OS.
 
 ```@docs
 quickbb

--- a/src/QXGraphDecompositions.jl
+++ b/src/QXGraphDecompositions.jl
@@ -1,4 +1,4 @@
-module QXGraphs
+module QXGraphDecompositions
 
 include("LabeledGraph.jl")
 include("treewidth.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using QXGraphs
+using QXGraphDecompositions
 using Test
 
 import LightGraphs; lg = LightGraphs


### PR DESCRIPTION
### Summary

Update the package name to QXGraphDecompositions.

### Rationale

The name change is required to avoid conflicts when automatically registering it as a Julia package.

#### Implementation Details

#### Additional notes

Closes #3 

***Check before merging:***

- [x] All discussions are resolved
- [x] New code is covered by appropriate tests
- [x] Tests are passing locally and on CI
- [x] The documentation is consistent with changes
- [x] Any code that was copied from other sources has the paper/url in a comment and is compatible with the MIT licence
- [x] Notebooks/examples not covered by unittests have been tested and updated as required
- [x] The feature branch is up-to-date with the master branch (rebase if behind)
- [x] Incremented the version string in Project.toml file
