### PR TITLE
Expose seed kwarg in flow cutter

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QXGraphDecompositions"
 uuid = "b15f1ded-d19a-4aca-a940-1991fcfc7750"
 authors = ["QuantEx team"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 FlowCutterPACE17_jll = "008204e2-cd5c-5c6d-9360-d31f32b5f6c2"

--- a/test/elimination_order_tests.jl
+++ b/test/elimination_order_tests.jl
@@ -43,7 +43,7 @@
 
     # Get a tree decomposition of the square lattice graph and test converting it to an
     # elimination order.
-    tree_decomp = flow_cutter(G; time=15)
+    tree_decomp = flow_cutter(G, 15)
     td_order = order_from_tree_decomposition(tree_decomp)
     @test find_treewidth_from_order(G, td_order) == tree_decomp[:treewidth]
     @test length(td_order) == N*N

--- a/test/flow_cutter_tests.jl
+++ b/test/flow_cutter_tests.jl
@@ -10,7 +10,7 @@
 
     # Check if the treewidth and number of bags is correct and check that the tree 
     # decomposition has no edges.
-    tree_decomp = flow_cutter(G; time=20)
+    tree_decomp = flow_cutter(G, 30; seed=42)
     @test tree_decomp[:treewidth] == 9
     @test tree_decomp[:num_bags] == 1
     @test length(tree_decomp[:edges]) == 0
@@ -32,12 +32,9 @@
     end
 
     # Check if the treewidth, number of bags and number of edges is correct.
-    tree_decomp = flow_cutter(G; time=20)
+    tree_decomp = flow_cutter(G, 30)
     @test tree_decomp[:treewidth] == N-1
     @test tree_decomp[:num_bags] == 2
+    @test tree_decomp[:num_vertices] == N + n
     @test length(tree_decomp[:edges]) == 1
-
-    # Check that an empty dictionary is returned if no tree decomposition is found.
-    tree_decomp = flow_cutter(G; time=0)
-    @test isempty(tree_decomp)
 end


### PR DESCRIPTION
### Summary

The flow cutter algorithm takes an argument to set the seed it uses. This is now exposed to the user through a kwarg for the exported flow cutter function.

The time argument for flow cutter was also updated to be an argument of flow cutter rather than a kwarg.

### Rationale

The seed argument was added for completeness and the time argument was updated for convenience.

#### Implementation Details

#### Additional notes

Closes #8 

***Check before merging:***

- [x] All discussions are resolved
- [x] New code is covered by appropriate tests
- [x] Tests are passing locally and on CI
- [x] The documentation is consistent with changes
- [x] Any code that was copied from other sources has the paper/url in a comment and is compatible with the MIT licence
- [x] Notebooks/examples not covered by unittests have been tested and updated as required
- [x] The feature branch is up-to-date with the master branch (rebase if behind)
- [x] Incremented the version string in Project.toml file
