### PR TITLE
Fix reading flow cutter output

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QXGraphDecompositions"
 uuid = "b15f1ded-d19a-4aca-a940-1991fcfc7750"
 authors = ["QuantEx team"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 FlowCutterPACE17_jll = "008204e2-cd5c-5c6d-9360-d31f32b5f6c2"

--- a/src/treewidth.jl
+++ b/src/treewidth.jl
@@ -79,7 +79,7 @@ function flow_cutter(G::lg.AbstractGraph, time::Integer=10; seed::Integer=-1)
                 td[:num_vertices] = parse(Int, words[5])
             elseif words[1] == "b"
                 td[Symbol("b_"*words[2])] = parse.(Int, words[3:end])
-            else
+            elseif length(words) == 2
                 push!(td[:edges], (parse(Int, words[1]), parse(Int, words[2])))
             end
         end

--- a/test/flow_cutter_tests.jl
+++ b/test/flow_cutter_tests.jl
@@ -32,7 +32,7 @@
     end
 
     # Check if the treewidth, number of bags and number of edges is correct.
-    tree_decomp = flow_cutter(G, 30)
+    tree_decomp = flow_cutter(G, 30; seed=42)
     @test tree_decomp[:treewidth] == N-1
     @test tree_decomp[:num_bags] == 2
     @test tree_decomp[:num_vertices] == N + n


### PR DESCRIPTION
### Summary

A guard was added to the flow cutter function to avoid reading empty lines from the flow cutter output file.

### Rationale

This should fix the edge case described in issue #10 .

#### Implementation Details

#### Additional notes

Closes #10 

***Check before merging:***

- [x] All discussions are resolved
- [x] New code is covered by appropriate tests
- [x] Tests are passing locally and on CI
- [x] The documentation is consistent with changes
- [x] Any code that was copied from other sources has the paper/url in a comment and is compatible with the MIT licence
- [x] Notebooks/examples not covered by unittests have been tested and updated as required
- [x] The feature branch is up-to-date with the master branch (rebase if behind)
- [x] Incremented the version string in Project.toml file
