### PR TITLE
12 add tree trimming heuristic

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QXGraphDecompositions"
 uuid = "b15f1ded-d19a-4aca-a940-1991fcfc7750"
 authors = ["QuantEx team"]
-version = "0.1.6"
+version = "0.1.7"
 
 [deps]
 FlowCutterPACE17_jll = "008204e2-cd5c-5c6d-9360-d31f32b5f6c2"

--- a/src/LabeledGraph.jl
+++ b/src/LabeledGraph.jl
@@ -62,6 +62,26 @@ function graph_to_gr(G::lg.AbstractGraph, filename::String)
     end
 end
 
+"""
+    graph_from_gr(filename::String)
+
+Read a graph from the provided gr file.
+"""
+function graph_from_gr(filename::String)
+    lines = readlines(filename)
+
+    # Create a Graph with the correct number of vertices.
+    num_vertices, num_edges = parse.(Int, split(lines[1], ' ')[3:end])
+    G = lg.SimpleGraph(num_vertices)
+
+    # Add an edge to the graph for every other line in the file.
+    for line in lines[2:end]
+        src, dst = parse.(Int, split(line, ' '))
+        lg.add_edge!(G, src, dst)
+    end
+    LabeledGraph(G)
+end
+
 
 """
     graph_to_cnf(G::LabeledGraph, filename::String)
@@ -77,6 +97,26 @@ function graph_to_cnf(G::lg.AbstractGraph, filename::String)
             write(io, "$(e.src) $(e.dst) 0\n")
         end
     end
+end
+
+"""
+    graph_from_cnf(filename::String)
+
+Read a graph from the provided cnf file.
+"""
+function graph_from_cnf(filename::String)
+    lines = readlines(filename)
+
+    # Create a Graph with the correct number of vertices.
+    num_vertices, num_edges = parse.(Int, split(lines[1], ' ')[3:end])
+    G = lg.SimpleGraph(num_vertices)
+
+    # Add an edge to the graph for every other line in the file.
+    for line in lines[2:end]
+        src, dst = parse.(Int, split(line, ' ')[1:2])
+        lg.add_edge!(G, src, dst)
+    end
+    LabeledGraph(G)
 end
 
 

--- a/src/treewidth.jl
+++ b/src/treewidth.jl
@@ -1,6 +1,6 @@
 using FlowCutterPACE17_jll
 
-import LightGraphs as lg
+import LightGraphs; lg = LightGraphs
 
 export flow_cutter
 export min_fill, order_from_tree_decomposition, restricted_mcs, find_treewidth_from_order

--- a/src/treewidth.jl
+++ b/src/treewidth.jl
@@ -5,7 +5,6 @@ import LightGraphs; lg = LightGraphs
 export flow_cutter
 export min_fill, order_from_tree_decomposition, restricted_mcs, find_treewidth_from_order
 export greedy_treewidth_deletion, direct_treewidth_score, build_clique_tree
-export quickbb
 
 
 
@@ -188,7 +187,7 @@ end
 
 Return a vertex elimination order with the same treewidth as the given tree decompositon.
 
-The alogithm used to construct the vertex elimination order is described by Shutski et al in
+The algorithm used to construct the vertex elimination order is described by Shutski et al in
 the following paper https://doi.org/10.1103/PhysRevA.102.062614
 
 # Keywords
@@ -307,7 +306,7 @@ end
 """
     greedy_treewidth_deletion(G::LabeledGraph, m::Int=4;
                               score_function::Symbol=:degree, 
-                              π::Array{Symbol, 1}=[])
+                              elim_order::Array{Symbol, 1}=[])
 
 Greedily remove vertices from G with respect to minimising the chosen score function.
 Return the reduced graph and an array of vertices which were removed.
@@ -319,12 +318,12 @@ The algorithm is described by Schutski et al in Phys. Rev. A 102, 062614.
 
 # Keywords
 - `score_function::Symbol=:degree`: function to maximise when selecting vertices to remove.
-                                    (:degree, :direct_treewidth)
+                                    (:degree, :direct_treewidth, :tree_trimming)
 - `elim_order::Array{Symbol, 1}=Symbol[]`: The elimination order for G to be used by 
                                            direct_treewidth score function.
 """
 function greedy_treewidth_deletion(G::LabeledGraph, m::Int=4;
-                                   score_function::Symbol=:degree, 
+                                   score_function::Symbol=:tree_trimming, 
                                    elim_order::Array{Symbol, 1}=Symbol[])
     # Check if keyword arguments are suitable.
     if !(score_function in keys(SCORES)) 

--- a/test/elimination_order_tests.jl
+++ b/test/elimination_order_tests.jl
@@ -35,6 +35,11 @@
     # Test finding the treewidth of an elimination order.
     @test find_treewidth_from_order(G, min_fill_order) == N-1
 
+    # Test constructing a teee decomposition from an elimination order
+    B, T = build_clique_tree(G, min_fill_order)
+    @test length(B) == lg.nv(T)
+    @test treewidth_upperbound == maximum(length.(B)) - 1
+
     # Turn the first 4 vertices og the graph into a clique for test restricted mcs.
     n = 4
     for i = 1:n-1, j = i+1:n

--- a/test/elimination_order_tests.jl
+++ b/test/elimination_order_tests.jl
@@ -61,51 +61,51 @@
     @test tree_decomp[:treewidth] == find_treewidth_from_order(G, modified_order)
 end
 
-@testset "QuickBB tests" begin
-    # A simple graph to test quickbb on.
-    N = 10
-    G = lg.SimpleGraph(N)
-    for i = 1:N
-        for j = i+1:N
-            lg.add_edge!(G, i, j)
-        end
-    end
+# @testset "QuickBB tests" begin
+#     # A simple graph to test quickbb on.
+#     N = 10
+#     G = lg.SimpleGraph(N)
+#     for i = 1:N
+#         for j = i+1:N
+#             lg.add_edge!(G, i, j)
+#         end
+#     end
 
-    # check if the treewidth is correct, the peo has the correct length and doesn'tensor
-    # contain repeated vertices. 
-    peo, md = quickbb(G)
-    @test md[:treewidth] == 9
-    @test length(peo) == N
-    @test length(Set(peo)) == N
+#     # check if the treewidth is correct, the peo has the correct length and doesn'tensor
+#     # contain repeated vertices. 
+#     peo, md = quickbb(G)
+#     @test md[:treewidth] == 9
+#     @test length(peo) == N
+#     @test length(Set(peo)) == N
 
-    peo, md = quickbb(G; time=5)
-    @test md[:treewidth] == 9
-    @test length(peo) == N
-    @test length(Set(peo)) == N
+#     peo, md = quickbb(G; time=5)
+#     @test md[:treewidth] == 9
+#     @test length(peo) == N
+#     @test length(Set(peo)) == N
 
-    peo, md = quickbb(G; order=:min_fill)
-    @test md[:treewidth] == 9
-    @test length(peo) == N
-    @test length(Set(peo)) == N
+#     peo, md = quickbb(G; order=:min_fill)
+#     @test md[:treewidth] == 9
+#     @test length(peo) == N
+#     @test length(Set(peo)) == N
 
-    peo, md = quickbb(G; order=:random)
-    @test md[:treewidth] == 9
-    @test length(peo) == N
-    @test length(Set(peo)) == N
+#     peo, md = quickbb(G; order=:random)
+#     @test md[:treewidth] == 9
+#     @test length(peo) == N
+#     @test length(Set(peo)) == N
 
-    peo, md = quickbb(G; order=:min_fill, lb=true)
-    @test md[:treewidth] == 9
-    @test length(peo) == N
-    @test length(Set(peo)) == N
+#     peo, md = quickbb(G; order=:min_fill, lb=true)
+#     @test md[:treewidth] == 9
+#     @test length(peo) == N
+#     @test length(Set(peo)) == N
 
-    peo, md = quickbb(G; time=5, order=:min_fill, lb=true)
-    @test md[:treewidth] == 9
-    @test length(peo) == N
-    @test length(Set(peo)) == N
+#     peo, md = quickbb(G; time=5, order=:min_fill, lb=true)
+#     @test md[:treewidth] == 9
+#     @test length(peo) == N
+#     @test length(Set(peo)) == N
 
-    G = LabeledGraph(G, [Symbol(:vert_, v) for v in 1:lg.nv(G)])
-    peo, md = quickbb(G)
-    @test md[:treewidth] == 9
-    @test typeof(peo) == Array{Symbol, 1}
-    @test Set(peo) == Set([Symbol(:vert_, v) for v in 1:nv(G)])
-end
+#     G = LabeledGraph(G, [Symbol(:vert_, v) for v in 1:lg.nv(G)])
+#     peo, md = quickbb(G)
+#     @test md[:treewidth] == 9
+#     @test typeof(peo) == Array{Symbol, 1}
+#     @test Set(peo) == Set([Symbol(:vert_, v) for v in 1:nv(G)])
+# end

--- a/test/elimination_order_tests.jl
+++ b/test/elimination_order_tests.jl
@@ -20,7 +20,7 @@
     N = 5
     G = LabeledGraph(N*N)
     for i = 1:N-1
-        for j = 1:N-1
+        for j = 1:N
             add_edge!(G, i + N*(j-1), i + N*(j-1) + 1)
             add_edge!(G, i + N*(j-1), i + N*(j-1) + N)
         end
@@ -34,11 +34,6 @@
 
     # Test finding the treewidth of an elimination order.
     @test find_treewidth_from_order(G, min_fill_order) == N-1
-
-    # Test constructing a teee decomposition from an elimination order
-    B, T = build_clique_tree(G, min_fill_order)
-    @test length(B) == lg.nv(T)
-    @test treewidth_upperbound == maximum(length.(B)) - 1
 
     # Turn the first 4 vertices og the graph into a clique for test restricted mcs.
     n = 4

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,5 +5,5 @@ import LightGraphs; lg = LightGraphs
 
 include("LabeledGraph_tests.jl")
 include("elimination_order_tests.jl")
-include("flow_cutter_tests.jl")
+include("tree_decomposition_tests.jl")
 include("treewidth_deletion_tests.jl")

--- a/test/tree_decomposition_tests.jl
+++ b/test/tree_decomposition_tests.jl
@@ -1,4 +1,4 @@
-@testset "Flow Cutter tests" begin
+@testset "Tree decomposition tests" begin
     # A simple graph to test flow cutter on.
     N = 10
     G = lg.SimpleGraph(N)
@@ -37,4 +37,20 @@
     @test tree_decomp[:num_bags] == 2
     @test tree_decomp[:num_vertices] == N + n
     @test length(tree_decomp[:edges]) == 1
+
+    # Test constructing a tree decomposition from an elimination order
+    # A square lattice graph to test the min fill heuristic and conversion of a tree 
+    # decomposition to an elimination order.
+    N = 5
+    G = LabeledGraph(N*N)
+    for i = 1:N-1
+        for j = 1:N
+            add_edge!(G, i + N*(j-1), i + N*(j-1) + 1)
+            add_edge!(G, i + N*(j-1), i + N*(j-1) + N)
+        end
+    end
+    treewidth_upperbound, min_fill_order = min_fill(G)
+    B, T = build_clique_tree(G, min_fill_order)
+    @test length(B) == lg.nv(T)
+    @test treewidth_upperbound == maximum(length.(B)) - 1
 end

--- a/test/treewidth_deletion_tests.jl
+++ b/test/treewidth_deletion_tests.jl
@@ -18,7 +18,7 @@
 
     # check if the treewidth is reduced by the correct amount and number of vertices removed
     # is correct.
-    Ḡ, μ = greedy_treewidth_deletion(G, 5)
+    Ḡ, μ = greedy_treewidth_deletion(G, 5; score_function=:degree)
     modified_tw, modifued_π̄ = min_fill(Ḡ)
     @test modified_tw == tw - 5
     @test nv(Ḡ) == 15
@@ -32,7 +32,7 @@
     @test length(π̃s[end]) == nv(Ḡ)
 
     # Test the tree trimming method for selecting vertices to delete.
-    Ḡ, μ, π̃s, τs = greedy_treewidth_deletion(G, 5; score_function=:tree_trimming, elim_order=π̄)
+    Ḡ, μ, π̃s, τs = greedy_treewidth_deletion(G, 5; elim_order=π̄)
     @test τs == [tw-1, tw-2, tw-3, tw-4, tw-5]
     @test nv(Ḡ) == 15
     @test length(μ) == 5

--- a/test/treewidth_deletion_tests.jl
+++ b/test/treewidth_deletion_tests.jl
@@ -30,4 +30,7 @@
     @test nv(Ḡ) == 15
     @test length(μ) == 5
     @test length(π̃s[end]) == nv(Ḡ)
+
+
+    
 end

--- a/test/treewidth_deletion_tests.jl
+++ b/test/treewidth_deletion_tests.jl
@@ -1,5 +1,5 @@
 @testset "Treewidth deletion tests" begin
-    # A simple graph to test quickbb on.
+    # A simple graph to test on.
     N = 10
     G = lg.SimpleGraph(N)
     for i = 1:N
@@ -14,13 +14,13 @@
     end
 
     G = LabeledGraph(G)
-    π̄, md = quickbb(G); tw = md[:treewidth]
+    tw, π̄ = min_fill(G)
 
     # check if the treewidth is reduced by the correct amount and number of vertices removed
     # is correct.
     Ḡ, μ = greedy_treewidth_deletion(G, 5)
-    peo, modified_md = quickbb(Ḡ)
-    @test modified_md[:treewidth] == tw - 5
+    modified_tw, modifued_π̄ = min_fill(Ḡ)
+    @test modified_tw == tw - 5
     @test nv(Ḡ) == 15
     @test length(μ) == 5
 

--- a/test/treewidth_deletion_tests.jl
+++ b/test/treewidth_deletion_tests.jl
@@ -17,7 +17,7 @@
     π̄, md = quickbb(G); tw = md[:treewidth]
 
     # check if the treewidth is reduced by the correct amount and number of vertices removed
-    # is correct. 
+    # is correct.
     Ḡ, μ = greedy_treewidth_deletion(G, 5)
     peo, modified_md = quickbb(Ḡ)
     @test modified_md[:treewidth] == tw - 5
@@ -31,6 +31,10 @@
     @test length(μ) == 5
     @test length(π̃s[end]) == nv(Ḡ)
 
-
-    
+    # Test the tree trimming method for selecting vertices to delete.
+    Ḡ, μ, π̃s, τs = greedy_treewidth_deletion(G, 5; score_function=:tree_trimming, elim_order=π̄)
+    @test τs == [tw-1, tw-2, tw-3, tw-4, tw-5]
+    @test nv(Ḡ) == 15
+    @test length(μ) == 5
+    @test length(π̃s[end]) == nv(Ḡ)
 end


### PR DESCRIPTION
### Summary

An implementation of the tree trimming score described in the shutski paper was added.
The greedy treewidth deletion function was updated to work with the new tree trimming function.
A `build_clique_tree` function was added to construct a tree decomposition from am elimination order for a graph.
Functions for reading a graph from .gr and .cnf files were also added.
Quickbb tests were removed and quickbb was un-exported to improve platform independence.

### Rationale

The tree trimming score outperforms the direct treewidth and degree score functions for selecting vertices to remove from a graph in order to reduce its treewidth. This can be used to improve automatic slicing of tensor networks.

#### Implementation Details

#### Additional notes

Closes #12 

***Check before merging:***

- [x] All discussions are resolved
- [x] New code is covered by appropriate tests
- [x] Tests are passing locally and on CI
- [x] The documentation is consistent with changes
- [x] Any code that was copied from other sources has the paper/url in a comment and is compatible with the MIT licence
- [x] Notebooks/examples not covered by unittests have been tested and updated as required
- [x] The feature branch is up-to-date with the master branch (rebase if behind)
- [x] Incremented the version string in Project.toml file
