### PR TITLE
Add link to QXTools in docs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QXGraphDecompositions"
 uuid = "b15f1ded-d19a-4aca-a940-1991fcfc7750"
 authors = ["QuantEx team"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 FlowCutterPACE17_jll = "008204e2-cd5c-5c6d-9360-d31f32b5f6c2"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,7 +8,7 @@ QXGraphDecompositions is a Julia package for analysing and manipulating graph st
 describing tensor networks. It provides functions for solving graph theoretic problems 
 related to the task of efficiently slicing and contracting a tensor network.
 
-QXGraphDecompositions was developed as part of the QuantEx project, one of the individual 
+QXGraphDecompositions was developed as part of the [QuantEx](https://github.com/JuliaQX/QXTools.jl) project, one of the individual 
 software projects of WP8 of [PRACE](https://prace-ri.eu/) 6IP.
 
 


### PR DESCRIPTION
### Summary

Added a link to QXTools in the docs

### Rationale

Addressing comments made in https://github.com/JuliaQX/QXTools.jl/issues/44

#### Implementation Details

#### Additional notes

<hr>

***Check before merging:***

- [x] All discussions are resolved
- [x] New code is covered by appropriate tests
- [x] Tests are passing locally and on CI
- [x] The documentation is consistent with changes
- [x] Any code that was copied from other sources has the paper/url in a comment and is compatible with the MIT licence
- [x] Notebooks/examples not covered by unittests have been tested and updated as required
- [x] The feature branch is up-to-date with the master branch (rebase if behind)
- [x] Incremented the version string in Project.toml file
